### PR TITLE
Update action card component styling

### DIFF
--- a/src/components/ActionCard/ActionCard.scss
+++ b/src/components/ActionCard/ActionCard.scss
@@ -3,8 +3,8 @@
 
 .lyse-action-card {
   // === STYLES DE BASE ===
-  background-color: var(--background-neutral-faint-default);
-  border: 1px solid var(--border-default);
+  background-color: var(--background-neutral-faint-hover);
+  border: 1px solid var(--border-selected);
   border-radius: var(--layout-radius-xl);
   padding: var(--layout-padding-lg);
   width: 100%;
@@ -91,7 +91,7 @@
     cursor: not-allowed;
     
     &:hover {
-      border-color: var(--border-default);
+      border-color: var(--border-selected);
       box-shadow: none;
     }
   }

--- a/src/components/ActionCard/README.md
+++ b/src/components/ActionCard/README.md
@@ -57,8 +57,8 @@ Le composant utilise le composant Button avec toutes ses variantes :
 
 Le composant utilise parfaitement les variables sémantiques Figma :
 
-- **Background** : `--background-neutral-faint-default`
-- **Border** : `--border-default`, `--border-neutral-medium`
+- **Background** : `--background-neutral-faint-hover`
+- **Border** : `--border-selected`, `--border-neutral-medium`
 - **Typography** : `--font-family-content`, `--font-weight-accent`, `--font-weight-regular`
 - **Spacing** : `--layout-padding-lg`, `--layout-gap-lg`, `--layout-gap-xs`
 - **Radius** : `--layout-radius-xl`


### PR DESCRIPTION
## 📋 Description

Implémente les mises à jour de style pour le composant `Action Card` afin d'améliorer la hiérarchie visuelle et la cohérence, comme spécifié dans l'issue DEV-855.

## 🎯 Type de changement

- [ ] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [x] 🎨 Style/UI
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 🔧 Configuration

## 🔗 Issue liée

Closes #DEV-855

## 📸 Screenshots

[N/A]

## 🧪 Tests

- [x] J'ai testé localement
- [ ] Les tests passent
- [ ] J'ai ajouté de nouveaux tests si nécessaire

## 📋 Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai effectué un auto-review de mon code
- [ ] J'ai commenté mon code, particulièrement dans les parties difficiles à comprendre
- [x] J'ai créé la documentation correspondante
- [x] Mes changements ne génèrent pas de nouveaux warnings
- [ ] J'ai ajouté des tests qui prouvent que ma correction fonctionne
- [ ] Les tests unitaires et d'intégration passent avec mes changements
- [ ] J'ai mis à jour les tests si nécessaire

## 📚 Documentation

- [x] J'ai mis à jour la documentation
- [ ] J'ai ajouté des exemples d'usage si nécessaire

## 🔄 Dépendances

- [x] Cette PR ne dépend d'aucune autre PR
- [ ] Cette PR dépend de #[numéro de la PR] (à merger en premier)

## 📝 Notes additionnelles

Les styles de bordure et d'arrière-plan du composant `Action Card` ont été mis à jour pour correspondre aux nouvelles spécifications de design. Une vérification approfondie a été effectuée pour s'assurer que toutes les instances, y compris l'état `disabled:hover`, utilisent les nouvelles variables sémantiques (`--border-selected` et `--background-neutral-faint-hover`) pour une cohérence totale.

---
Linear Issue: [DEV-855](https://linear.app/lyse-labs/issue/DEV-855/updated-component-action-card)

<a href="https://cursor.com/background-agent?bcId=bc-d6506b98-3d3c-44c7-84a8-71d845f1c12c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6506b98-3d3c-44c7-84a8-71d845f1c12c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

