### PR TITLE
Update action card styling and check contrast

### DIFF
--- a/src/components/ActionCard/ActionCard.scss
+++ b/src/components/ActionCard/ActionCard.scss
@@ -3,8 +3,8 @@
 
 .lyse-action-card {
   // === STYLES DE BASE ===
-  background-color: var(--background-elevated);
-  border: 1px solid var(--border-divider);
+  background-color: var(--background-neutral-medium-default);
+  border: 1px solid var(--border-selected);
   border-radius: var(--layout-radius-xl);
   padding: var(--layout-padding-lg);
   width: 100%;
@@ -41,7 +41,7 @@
     font-size: var(--font-size-content-note);
     font-weight: var(--font-weight-regular);
     line-height: var(--font-line-height-content-note);
-    color: var(--text-base-moderate);
+    color: var(--text-base-strong);
     margin: 0;
     padding: 0;
   }

--- a/src/components/ActionCard/README.md
+++ b/src/components/ActionCard/README.md
@@ -57,8 +57,8 @@ Le composant utilise le composant Button avec toutes ses variantes :
 
 Le composant utilise parfaitement les variables sémantiques Figma :
 
-- **Background** : `--background-elevated`
-- **Border** : `--border-divider`, `--border-neutral-medium`
+- **Background** : `--background-neutral-medium-default`
+- **Border** : `--border-selected`, `--border-neutral-medium`
 - **Typography** : `--font-family-content`, `--font-weight-accent`, `--font-weight-regular`
 - **Spacing** : `--layout-padding-lg`, `--layout-gap-lg`, `--layout-gap-xs`
 - **Radius** : `--layout-radius-xl`


### PR DESCRIPTION
## 📋 Description

Cette PR met à jour le composant `Action Card` pour l'aligner avec le nouveau système de style `selected-state`, comme spécifié dans l'issue DEV-886.

Les changements incluent la mise à jour des variables CSS pour l'arrière-plan (`--background-elevated` → `--background-neutral-medium-default`) et la bordure (`--border-divider` → `--border-selected`).

Une amélioration proactive de l'accessibilité a également été intégrée en ajustant la couleur du texte de description (`--text-base-moderate` → `--text-base-strong`) pour garantir un contraste suffisant (conformité WCAG AA) avec le nouvel arrière-plan. La documentation du composant a été mise à jour en conséquence.

## 🎯 Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [x] 🎨 Style/UI
- [x] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 🔧 Configuration

## 🔗 Issue liée

Closes #DEV-886

## 📸 Screenshots

[N/A]

## 🧪 Tests

- [x] J'ai testé localement (build et linting)
- [x] Les tests passent (build et linting)
- [ ] J'ai ajouté de nouveaux tests si nécessaire

## 📋 Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai effectué un auto-review de mon code
- [ ] J'ai commenté mon code, particulièrement dans les parties difficiles à comprendre
- [x] J'ai créé la documentation correspondante
- [x] Mes changements ne génèrent pas de nouveaux warnings
- [ ] J'ai ajouté des tests qui prouvent que ma correction fonctionne
- [ ] Les tests unitaires et d'intégration passent avec mes changements
- [ ] J'ai mis à jour les tests si nécessaire

## 📚 Documentation

- [x] J'ai mis à jour la documentation (README.md du composant)
- [ ] J'ai ajouté des exemples d'usage si nécessaire

## 🔄 Dépendances

- [x] Cette PR ne dépend d'aucune autre PR
- [ ] Cette PR dépend de #[numéro de la PR] (à merger en premier)

## 📝 Notes additionnelles

L'arrière-plan `--background-neutral-medium-default` (#a5a5a5) a été introduit. Pour assurer la conformité WCAG AA, la couleur du texte de description a été passée de `--text-base-moderate` (#545454) à `--text-base-strong` (#1c1c1c), améliorant significativement le contraste.

---
Linear Issue: [DEV-886](https://linear.app/lyse-labs/issue/DEV-886/updated-component-action-card)

<a href="https://cursor.com/background-agent?bcId=bc-b8202901-ccf5-4fb5-aec1-336a2b49886f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8202901-ccf5-4fb5-aec1-336a2b49886f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

