### PR TITLE
Update action card styling

### DIFF
--- a/src/components/ActionCard/ActionCard.scss
+++ b/src/components/ActionCard/ActionCard.scss
@@ -3,8 +3,8 @@
 
 .lyse-action-card {
   // === STYLES DE BASE ===
-  background-color: var(--background-neutral-medium-default);
-  border: 1px solid var(--border-selected);
+  background-color: var(--background-neutral-lighter-default);
+  border: 1px solid var(--border-default);
   border-radius: var(--layout-radius-xl);
   padding: var(--layout-padding-lg);
   width: 100%;


### PR DESCRIPTION
## 📋 Description

Met à jour le style de la `Action Card` pour améliorer la hiérarchie visuelle. Le fond passe de `background-neutral-medium-default` à `background-neutral-lighter-default` et la bordure de `border-selected` à `border-default`.

## 🎯 Type de changement

- [ ] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [x] 🎨 Style/UI
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Test
- [ ] 🔧 Configuration

## 🔗 Issue liée

Closes #DEV-887

## 📸 Screenshots

[N/A]

## 🧪 Tests

- [x] J'ai testé localement
- [x] Les tests passent
- [ ] J'ai ajouté de nouveaux tests si nécessaire

## 📋 Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai effectué un auto-review de mon code
- [ ] J'ai commenté mon code, particulièrement dans les parties difficiles à comprendre
- [ ] J'ai créé la documentation correspondante
- [x] Mes changements ne génèrent pas de nouveaux warnings
- [ ] J'ai ajouté des tests qui prouvent que ma correction fonctionne
- [ ] Les tests unitaires et d'intégration passent avec mes changements
- [ ] J'ai mis à jour les tests si nécessaire

## 📚 Documentation

- [ ] J'ai mis à jour la documentation
- [ ] J'ai ajouté des exemples d'usage si nécessaire

## 🔄 Dépendances

- [x] Cette PR ne dépend d'aucune autre PR
- [ ] Cette PR dépend de #[numéro de la PR] (à merger en premier)

## 📝 Notes additionnelles

Vérification des ratios de contraste effectuée pour le mode clair, respecte les normes WCAG AA. Le mode sombre n'est pas implémenté dans la codebase actuelle.

---
Linear Issue: [DEV-887](https://linear.app/lyse-labs/issue/DEV-887/updated-component-action-card)

<a href="https://cursor.com/background-agent?bcId=bc-55193abb-9043-4f01-af3c-0a0fe0d9331c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-55193abb-9043-4f01-af3c-0a0fe0d9331c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

